### PR TITLE
Use duck-typing for recursing into layer groups

### DIFF
--- a/src/olgm/herald/Layers.js
+++ b/src/olgm/herald/Layers.js
@@ -270,7 +270,7 @@ class LayersHerald extends Herald {
     } else if (layer instanceof ImageLayer &&
           this.watchOptions_.image !== false) {
       this.imageWMSSourceHerald_.watchLayer(layer);
-    } else if (layer instanceof LayerGroup) {
+    } else if (layer instanceof LayerGroup || typeof layer.getLayers === 'function') {
       layer.getLayers().forEach(lyr => this.watchLayer_(lyr));
     }
   }
@@ -304,7 +304,7 @@ class LayersHerald extends Herald {
       this.tileSourceHerald_.unwatchLayer(layer);
     } else if (layer instanceof ImageLayer) {
       this.imageWMSSourceHerald_.unwatchLayer(layer);
-    } else if (layer instanceof LayerGroup) {
+    } else if (layer instanceof LayerGroup || typeof layer.getLayers === 'function') {
       layer.getLayers().forEach(layer => this.unwatchLayer_(layer));
     }
   }


### PR DESCRIPTION
**Why?** Most JS bundling scenarios don't preserve the class names which breaks cross-bundle `instanceof` checks.

This is the fix needed to fix the changes in https://github.com/symbioquine/farm_map_google/tree/2.x-development-wip and allow @paul121's `farm_map_google` module work against farmOS-map 2.x - https://github.com/farmOS/farmOS-map/issues/115

**What?** Recurse into layer groups either based on the `instanceof` check **or** the presence of a `getLayers` method.